### PR TITLE
Merge performs calls

### DIFF
--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
@@ -46,51 +46,63 @@ class DslRequestBuilder(private val requestBuilder: MockHttpServletRequestBuilde
         return result
     }
 
-    fun expectStatus(statusInit: StatusResultMatchers.() -> ResultMatcher) {
+    fun expectStatus(statusInit: StatusResultMatchers.() -> ResultMatcher): DslRequestBuilder {
         expect { status(statusInit) }
+        return this
     }
 
-    fun expectContent(contentInit: ContentResultMatchers.() -> ResultMatcher) {
+    fun expectContent(contentInit: ContentResultMatchers.() -> ResultMatcher): DslRequestBuilder {
         expect { content(contentInit) }
+        return this
     }
 
-    fun expectViewName(viewName: String) {
-        return expect {viewName(viewName)}
+    fun expectViewName(viewName: String): DslRequestBuilder {
+        expect {viewName(viewName)}
+        return this
     }
 
-    fun expectModel(modelInit: ModelResultMatchers.() -> ResultMatcher) {
+    fun expectModel(modelInit: ModelResultMatchers.() -> ResultMatcher): DslRequestBuilder {
         expect { model(modelInit) }
+        return this
     }
 
-    fun <T> expectModel(name: String, modelInit: T.() -> Unit) {
-        expect { model<T>(name, modelInit) }
+    fun <T> expectModel(name: String, modelInit: T.() -> Unit): DslRequestBuilder {
+        expect { model(name, modelInit) }
+        return this
     }
 
-    fun expectRedirectedUrl(expectedUrl: String) {
+    fun expectRedirectedUrl(expectedUrl: String): DslRequestBuilder {
         expect { redirectedUrl(expectedUrl)}
+        return this
     }
 
-    fun expectRedirectedUrlPattern(redirectedUrlPattern: String) {
+    fun expectRedirectedUrlPattern(redirectedUrlPattern: String): DslRequestBuilder {
         expect { redirectedUrlPattern(redirectedUrlPattern) }
+        return this
     }
 
-    fun expectHeader(headerInit: HeaderResultMatchers.() -> ResultMatcher) {
+    fun expectHeader(headerInit: HeaderResultMatchers.() -> ResultMatcher): DslRequestBuilder {
         expect { header(headerInit) }
+        return this
     }
 
-    fun expectFlash(flashInit: FlashAttributeResultMatchers.() -> ResultMatcher) {
+    fun expectFlash(flashInit: FlashAttributeResultMatchers.() -> ResultMatcher): DslRequestBuilder {
         expect { flash(flashInit) }
+        return this
     }
 
-    fun expectJsonPath(expression:String, vararg args:Any, jsonInit: JsonPathResultMatchers.() -> ResultMatcher) {
+    fun expectJsonPath(expression:String, vararg args:Any, jsonInit: JsonPathResultMatchers.() -> ResultMatcher): DslRequestBuilder {
         expect { jsonPath(expression, args = *arrayOf(args), jsonInit = jsonInit) }
+        return this
     }
 
-    fun expectXPath(expression:String, vararg args:Any, xpatInit: XpathResultMatchers.() -> ResultMatcher) {
+    fun expectXPath(expression:String, vararg args:Any, xpatInit: XpathResultMatchers.() -> ResultMatcher): DslRequestBuilder {
         expect { xPath(expression, args = *arrayOf(args), xpatInit = xpatInit) }
+        return this
     }
 
-    fun expectCookie(cookieInit: CookieResultMatchers.() -> ResultMatcher) {
+    fun expectCookie(cookieInit: CookieResultMatchers.() -> ResultMatcher): DslRequestBuilder {
         expect { cookie(cookieInit) }
+        return this
     }
 }

--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
@@ -2,8 +2,15 @@ package cz.petrbalat.spring.mvc.test.dsl
 
 import org.springframework.test.web.servlet.RequestBuilder
 import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.*
+
+@DslMarker
+annotation class RequestDsl
+
+@DslMarker
+annotation class ResultDsl
 
 @RequestDsl
 class DslRequestBuilder(private val requestBuilder: MockHttpServletRequestBuilder,
@@ -37,5 +44,53 @@ class DslRequestBuilder(private val requestBuilder: MockHttpServletRequestBuilde
         val expectationBuild = DslExpectationBuilder(result)
         expects.forEach { expectationBuild.apply(it) }
         return result
+    }
+
+    fun expectStatus(statusInit: StatusResultMatchers.() -> ResultMatcher) {
+        expect { status(statusInit) }
+    }
+
+    fun expectContent(contentInit: ContentResultMatchers.() -> ResultMatcher) {
+        expect { content(contentInit) }
+    }
+
+    fun expectViewName(viewName: String) {
+        return expect {viewName(viewName)}
+    }
+
+    fun expectModel(modelInit: ModelResultMatchers.() -> ResultMatcher) {
+        expect { model(modelInit) }
+    }
+
+    fun <T> expectModel(name: String, modelInit: T.() -> Unit) {
+        expect { model<T>(name, modelInit) }
+    }
+
+    fun expectRedirectedUrl(expectedUrl: String) {
+        expect { redirectedUrl(expectedUrl)}
+    }
+
+    fun expectRedirectedUrlPattern(redirectedUrlPattern: String) {
+        expect { redirectedUrlPattern(redirectedUrlPattern) }
+    }
+
+    fun expectHeader(headerInit: HeaderResultMatchers.() -> ResultMatcher) {
+        expect { header(headerInit) }
+    }
+
+    fun expectFlash(flashInit: FlashAttributeResultMatchers.() -> ResultMatcher) {
+        expect { flash(flashInit) }
+    }
+
+    fun expectJsonPath(expression:String, vararg args:Any, jsonInit: JsonPathResultMatchers.() -> ResultMatcher) {
+        expect { jsonPath(expression, args = *arrayOf(args), jsonInit = jsonInit) }
+    }
+
+    fun expectXPath(expression:String, vararg args:Any, xpatInit: XpathResultMatchers.() -> ResultMatcher) {
+        expect { xPath(expression, args = *arrayOf(args), xpatInit = xpatInit) }
+    }
+
+    fun expectCookie(cookieInit: CookieResultMatchers.() -> ResultMatcher) {
+        expect { cookie(cookieInit) }
     }
 }

--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
@@ -2,6 +2,7 @@ package cz.petrbalat.spring.mvc.test.dsl
 
 import org.springframework.test.web.servlet.RequestBuilder
 import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.ResultHandler
 import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import org.springframework.test.web.servlet.result.*
@@ -103,6 +104,16 @@ class DslRequestBuilder(private val requestBuilder: MockHttpServletRequestBuilde
 
     fun expectCookie(cookieInit: CookieResultMatchers.() -> ResultMatcher): DslRequestBuilder {
         expect { cookie(cookieInit) }
+        return this
+    }
+
+    fun andDo(action: ResultHandler): DslRequestBuilder {
+        actions { andDo(action)}
+        return this
+    }
+
+    fun andExpect(action: ResultMatcher): DslRequestBuilder {
+        actions { andExpect(action)}
         return this
     }
 }

--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/performs.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/performs.kt
@@ -1,5 +1,6 @@
 package cz.petrbalat.spring.mvc.test.dsl
 
+import org.springframework.http.HttpMethod
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.ResultActions
@@ -9,102 +10,81 @@ import java.net.URI
 
 
 //GET
-fun MockMvc.performGet(url:String, 
-                       requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                       init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.get(url), requestInit, init)
+fun MockMvc.performGet(url:String, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.get(url), block)
 }
 
-fun MockMvc.performGet(uri: URI,
-                       requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                       init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.get(uri), requestInit, init)
+fun MockMvc.performGet(uri: URI, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.get(uri), block)
 }
 
 //POST
-fun MockMvc.performPost(url:String, 
-                        requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                        init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.post(url), requestInit, init)
+fun MockMvc.performPost(url:String, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.post(url), block)
 }
 
-fun MockMvc.performPost(uri: URI,
-                        requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                        init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.post(uri), requestInit, init)
+fun MockMvc.performPost(uri: URI, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.post(uri), block)
 }
 
 //PUT
-fun MockMvc.performPut(url:String,
-                       requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                       init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.put(url), requestInit, init)
+fun MockMvc.performPut(url:String, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.put(url), block)
 }
 
-fun MockMvc.performPut(uri: URI,
-                       requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                       init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.put(uri), requestInit, init)
+fun MockMvc.performPut(uri: URI, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.put(uri), block)
 }
 
 //DELETE
-fun MockMvc.performDelete(url:String,
-                          requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                          init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.delete(url), requestInit, init)
+fun MockMvc.performDelete(url:String, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.delete(url), block)
 }
 
-fun MockMvc.performDelete(uri: URI,
-                          requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                          init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.delete(uri), requestInit, init)
+fun MockMvc.performDelete(uri: URI, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.delete(uri), block)
 }
 
 //HEAD
-fun MockMvc.performHead(url:String,
-                        requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                        init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.head(url), requestInit, init)
+fun MockMvc.performHead(url:String, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.head(url), block)
 }
 
-fun MockMvc.performHead(uri: URI,
-                        requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                        init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.head(uri), requestInit, init)
+fun MockMvc.performHead(uri: URI, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.head(uri), block)
 }
 
 //PATCH
-fun MockMvc.performPatch(url:String,
-                         requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                         init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.patch(url), requestInit, init)
+fun MockMvc.performPatch(url:String, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.patch(url), block)
 }
 
-fun MockMvc.performPatch(uri: URI,
-                         requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                         init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.patch(uri), requestInit, init)
+fun MockMvc.performPatch(uri: URI, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.patch(uri), block)
 }
 
 //OPTIONS
-fun MockMvc.performOptions(url:String,
-                           requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                           init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.options(url), requestInit, init)
+fun MockMvc.performOptions(url:String, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.options(url), block)
 }
 
-fun MockMvc.performOptions(uri: URI,
-                           requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                           init: ResultActions.() -> Unit): MvcResult {
-    return performDsl(this, MockMvcRequestBuilders.options(uri), requestInit, init)
+fun MockMvc.performOptions(uri: URI, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.options(uri), block)
+}
+
+//REQUEST
+fun MockMvc.perform(method: HttpMethod, url: String, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.request(method, url), block)
+}
+
+fun MockMvc.perform(method: HttpMethod, uri: URI, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    return performDsl(this, MockMvcRequestBuilders.request(method, uri), block)
 }
 
 private fun performDsl(mockMvc: MockMvc,
-                       request: MockHttpServletRequestBuilder,
-                       requestInit: MockHttpServletRequestBuilder.() -> Unit,
-                       init: ResultActions.() -> Unit): MvcResult {
-    request.requestInit()
-    val perform = mockMvc.perform(request)
-    perform.init()
-    return perform.andReturn()
+                       requestBuilder: MockHttpServletRequestBuilder,
+                       block: DslRequestBuilder.() -> Unit = {}): MvcResult {
+    val request = DslRequestBuilder(requestBuilder).apply(block)
+    val result = mockMvc.perform(request.buildRequest())
+    return request.applyResult(result).andReturn()
 }

--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/providers.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/providers.kt
@@ -1,6 +1,8 @@
 package cz.petrbalat.spring.mvc.test.dsl
 
+import org.springframework.http.HttpMethod
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import java.net.URI
@@ -12,72 +14,73 @@ interface MockMvcProvider {
 }
 
 //GET
-fun MockMvcProvider.performGet(url:String, 
-                               requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                               init: ResultActions.() -> Unit) {
-    this.mockMvc.performGet(url = url, requestInit = requestInit, init = init)
+fun MockMvcProvider.performGet(url: String, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performGet(url = url, block = block)
 }
 
-fun MockMvcProvider.performGet(uri: URI,
-                               requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                               init: ResultActions.() -> Unit) {
-    this.mockMvc.performGet(uri = uri, requestInit = requestInit, init = init)
+fun MockMvcProvider.performGet(uri: URI, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performGet(uri = uri, block = block)
 }
 
 //POST
-fun MockMvcProvider.performPost(url:String, 
-                        requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                        init: ResultActions.() -> Unit) {
-    this.mockMvc.performPost(url = url, requestInit = requestInit, init = init)
+fun MockMvcProvider.performPost(url: String, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performPost(url = url, block = block)
 }
 
-fun MockMvcProvider.performPost(uri: URI,
-                                requestInit: MockHttpServletRequestBuilder.() -> Unit = {},
-                                init: ResultActions.() -> Unit) {
-    this.mockMvc.performPost(uri = uri, requestInit = requestInit ,init = init)
+fun MockMvcProvider.performPost(uri: URI, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performPost(uri = uri, block = block)
 }
 
 //PUT
-fun MockMvcProvider.performPut(url:String,  init: ResultActions.() -> Unit) {
-    this.mockMvc.performPut(url = url, init = init)
+fun MockMvcProvider.performPut(url: String, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performPut(url = url, block = block)
 }
 
-fun MockMvcProvider.performPut(uri: URI, init: ResultActions.() -> Unit) {
-    this.mockMvc.performPut(uri = uri, init = init)
+fun MockMvcProvider.performPut(uri: URI, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performPut(uri = uri, block = block)
 }
 
 //DELETE
-fun MockMvcProvider.performDelete(url:String,  init: ResultActions.() -> Unit) {
-    this.mockMvc.performDelete(url = url, init = init)
+fun MockMvcProvider.performDelete(url: String, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performDelete(url = url, block = block)
 }
 
-fun MockMvcProvider.performDelete(uri: URI, init: ResultActions.() -> Unit) {
-    this.mockMvc.performDelete(uri = uri, init = init)
+fun MockMvcProvider.performDelete(uri: URI, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performDelete(uri = uri, block = block)
 }
 
 //HEAD
-fun MockMvcProvider.performHead(url:String,  init: ResultActions.() -> Unit) {
-    this.mockMvc.performHead(url = url, init = init)
+fun MockMvcProvider.performHead(url: String, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performHead(url = url, block = block)
 }
 
-fun MockMvcProvider.performHead(uri: URI, init: ResultActions.() -> Unit) {
-    this.mockMvc.performHead(uri = uri, init = init)
+fun MockMvcProvider.performHead(uri: URI, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performHead(uri = uri, block = block)
 }
 
 //PATCH
-fun MockMvcProvider.performPatch(url:String,  init: ResultActions.() -> Unit) {
-    this.mockMvc.performPatch(url = url, init = init)
+fun MockMvcProvider.performPatch(url: String, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performPatch(url = url, block = block)
 }
 
-fun MockMvcProvider.performPatch(uri: URI, init: ResultActions.() -> Unit) {
-    this.mockMvc.performPatch(uri = uri, init = init)
+fun MockMvcProvider.performPatch(uri: URI, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performPatch(uri = uri, block = block)
 }
 
 //OPTIONS
-fun MockMvcProvider.performOptions(url:String,  init: ResultActions.() -> Unit) {
-    this.mockMvc.performOptions(url = url, init = init)
+fun MockMvcProvider.performOptions(url: String, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performOptions(url = url, block = block)
 }
 
-fun MockMvcProvider.performOptions(uri: URI, init: ResultActions.() -> Unit) {
-    this.mockMvc.performOptions(uri = uri, init = init)
+fun MockMvcProvider.performOptions(uri: URI, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.performOptions(uri = uri, block = block)
+}
+
+//REQUESTS
+fun MockMvcProvider.perform(method: HttpMethod, url: String, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.perform(method = method, url = url, block = block)
+}
+
+fun MockMvcProvider.perform(method: HttpMethod, uri: URI, block: DslRequestBuilder.() -> Unit = {}) {
+    this.mockMvc.perform(method = method, uri = uri, block = block)
 }

--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/requestDsl.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/requestDsl.kt
@@ -8,17 +8,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 
 
-@DslMarker
-annotation class RequestDsl
 
-@DslMarker
-annotation class ResultDsl
-
-fun MockMvc.request(method: HttpMethod, url: String, block: DslRequestBuilder.() -> Unit = {}): MvcResult {
-    val request = DslRequestBuilder(MockMvcRequestBuilders.request(method, url)).apply(block)
-    val result = this.perform(request.buildRequest())
-    return request.applyResult(result).andReturn()
-}
 
 fun MockHttpServletRequestBuilder.jsonContent(jsonContent: String) {
     content(jsonContent)

--- a/src/test/kotlin/cz/petrbalat/spring/mvc/test/dsl/controller/DslControllerTest.kt
+++ b/src/test/kotlin/cz/petrbalat/spring/mvc/test/dsl/controller/DslControllerTest.kt
@@ -11,6 +11,10 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultHandler
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import javax.servlet.http.Cookie
@@ -30,9 +34,11 @@ class DslControllerTest : MockMvcProvider {
     @Test
     fun helloGet() {
         mockMvc.performGet("/hello?name=Petr") {
-            expectStatus { isOk }
+            andDo(print())
+            .andExpect(status().isOk) //legacy andDo/andExpect can still be used
+            .expectStatus { isOk } //chaining is supported but not really necessary
             expectContent { contentTypeCompatibleWith(MediaType.TEXT_HTML) }
-            .expectViewName("hello") //chaining is supported but not really necessary
+            expectViewName("hello")
 
             expectModel {
                 size<Any>(1)

--- a/src/test/kotlin/cz/petrbalat/spring/mvc/test/dsl/controller/DslControllerTest.kt
+++ b/src/test/kotlin/cz/petrbalat/spring/mvc/test/dsl/controller/DslControllerTest.kt
@@ -32,7 +32,7 @@ class DslControllerTest : MockMvcProvider {
         mockMvc.performGet("/hello?name=Petr") {
             expectStatus { isOk }
             expectContent { contentTypeCompatibleWith(MediaType.TEXT_HTML) }
-            expectViewName("hello")
+            .expectViewName("hello") //chaining is supported but not really necessary
 
             expectModel {
                 size<Any>(1)

--- a/src/test/kotlin/cz/petrbalat/spring/mvc/test/dsl/controller/DslControllerTest.kt
+++ b/src/test/kotlin/cz/petrbalat/spring/mvc/test/dsl/controller/DslControllerTest.kt
@@ -72,17 +72,10 @@ class DslControllerTest : MockMvcProvider {
     }
 
     @Test
-    fun helloPost() = performPost("/hello", {
-        contentType(MediaType.APPLICATION_FORM_URLENCODED)
-        param("surname", "Balat")
-    }) {
-        expectStatus { isOk }
-        expectContent { contentTypeCompatibleWith(MediaType.TEXT_HTML) }
-        expectViewName("hello")
-
-        expectModel {
-            size<Any>(2)
-            attribute("helloPostDto", HelloPostDto("Balat"))
+    fun helloPost() = performPost("/hello") {
+        builder {
+            contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            param("surname", "Balat")
         }
 
         expectModel<HelloPostDto>("helloPostDto") {
@@ -101,7 +94,7 @@ class DslControllerTest : MockMvcProvider {
 
     @Test
     fun `hello put with required parameters of method and url`() {
-        mockMvc.request(HttpMethod.PUT, "/hello") {
+        mockMvc.perform(HttpMethod.PUT, "/hello") {
             builder {
                 contentType(MediaType.APPLICATION_JSON)
                 content("""{"surname": "Jack"}""")
@@ -118,7 +111,7 @@ class DslControllerTest : MockMvcProvider {
 
     @Test
     fun `minimal call, builder, and expectation`() {
-        mockMvc.request(HttpMethod.GET, "/hello") {
+        mockMvc.perform(HttpMethod.GET, "/hello") {
             builder { param("name", "world") }
             expect { status { isOk } }
         }


### PR DESCRIPTION
This removes the `request` method and renames it to `perform`. I like how that keeps it aligned with the default MockMvc call.

It also updates all the `performGet` and similar to use the same DSL. I added the `expectStatus` etc methods to the `DslRequestBuilder` so it avoids most of the potential breaking changes, however there are still some breaking changes.

Breaking
* You can still chain `expectStatus` and similar methods when in the DSL but since the return type changed you could still be required to change code
* the `requestInit()` block for existing code must be moved into the `builder` block