### PR TITLE
Add unary operator and merge expects into normal actions flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ fun helloGet() {
 Gradle:
 ```
 repositories {
-    url("https://mymavenrepo.com/repo/plFabfZlZhQO7UjsJKDc/")
+    maven {url("https://mymavenrepo.com/repo/plFabfZlZhQO7UjsJKDc/")}
 }
     
 ...

--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslExpectationBuilder.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslExpectationBuilder.kt
@@ -1,6 +1,7 @@
 package cz.petrbalat.spring.mvc.test.dsl
 
 import org.hamcrest.CoreMatchers
+import org.hamcrest.Matcher
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.ResultMatcher
@@ -56,13 +57,18 @@ class DslExpectationBuilder(private val actions: ResultActions) {
         actions.andExpect(flash)
     }
 
-    fun jsonPath(expression:String, vararg args:Any, jsonInit: JsonPathResultMatchers.() -> ResultMatcher) {
-        val json = MockMvcResultMatchers.jsonPath(expression, args).jsonInit()
+    fun <T> jsonPath(expression:String, matcher : Matcher<T>) {
+        val json = MockMvcResultMatchers.jsonPath(expression, matcher)
         actions.andExpect(json)
     }
 
-    fun xPath(expression:String, vararg args:Any, xpatInit: XpathResultMatchers.() -> ResultMatcher) {
-        val xpath = MockMvcResultMatchers.xpath(expression, args).xpatInit()
+    fun jsonPath(expression:String, vararg args:Any, block: JsonPathResultMatchers.() -> ResultMatcher) {
+        val xpath = MockMvcResultMatchers.jsonPath(expression, args).block()
+        actions.andExpect(xpath)
+    }
+
+    fun xPath(expression:String, vararg args:Any, xpathInit: XpathResultMatchers.() -> ResultMatcher) {
+        val xpath = MockMvcResultMatchers.xpath(expression, args).xpathInit()
         actions.andExpect(xpath)
     }
 
@@ -79,8 +85,20 @@ class DslExpectationBuilder(private val actions: ResultActions) {
         content { string(value) }
     }
 
+    infix fun String.jsonPath(block: JsonPathResultMatchers.() -> ResultMatcher) {
+        actions.andExpect(MockMvcResultMatchers.jsonPath(this).block())
+    }
+
     infix fun String.jsonPathIs(value: Any) {
         actions.andExpect(MockMvcResultMatchers.jsonPath(this, CoreMatchers.`is`(value)))
+    }
+
+    infix fun <T> String.jsonPathMatcher(value: Matcher<T>) {
+        actions.andExpect(MockMvcResultMatchers.jsonPath(this, value))
+    }
+
+    operator fun ResultMatcher.unaryPlus(){
+        actions.andExpect(this)
     }
 
     fun json(jsonContent: String, strict: Boolean = false) {

--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
@@ -17,8 +17,6 @@ class DslRequestBuilder(private val requestBuilder: MockHttpServletRequestBuilde
 
     private val actions: MutableList<ResultActions.() -> Unit> = mutableListOf()
 
-    private val expects: MutableList<DslExpectationBuilder.() -> Unit> = mutableListOf()
-
     fun printRequestAndResponse() {
         actions { andDo(MockMvcResultHandlers.print()) }
     }
@@ -28,7 +26,7 @@ class DslRequestBuilder(private val requestBuilder: MockHttpServletRequestBuilde
     }
 
     fun expect(block: DslExpectationBuilder.() -> Unit) {
-        this.expects.add(block)
+        this.actions { DslExpectationBuilder(this).apply(block) }
     }
 
     fun actions(block: ResultActions.() -> Unit) {
@@ -42,8 +40,6 @@ class DslRequestBuilder(private val requestBuilder: MockHttpServletRequestBuilde
 
     fun applyResult(result: ResultActions): ResultActions {
         actions.forEach { result.apply(it) }
-        val expectationBuild = DslExpectationBuilder(result)
-        expects.forEach { expectationBuild.apply(it) }
         return result
     }
 

--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
@@ -88,13 +88,13 @@ class DslRequestBuilder(private val requestBuilder: MockHttpServletRequestBuilde
         return this
     }
 
-    fun expectJsonPath(expression:String, vararg args:Any, jsonInit: JsonPathResultMatchers.() -> ResultMatcher): DslRequestBuilder {
-        expect { jsonPath(expression, args = *arrayOf(args), jsonInit = jsonInit) }
+    fun expectJsonPath(expression:String, vararg args:Any, block: JsonPathResultMatchers.() -> ResultMatcher): DslRequestBuilder {
+        expect { jsonPath(expression, args = *arrayOf(args), block = block) }
         return this
     }
 
-    fun expectXPath(expression:String, vararg args:Any, xpatInit: XpathResultMatchers.() -> ResultMatcher): DslRequestBuilder {
-        expect { xPath(expression, args = *arrayOf(args), xpatInit = xpatInit) }
+    fun expectXPath(expression:String, vararg args:Any, xpathInit: XpathResultMatchers.() -> ResultMatcher): DslRequestBuilder {
+        expect { xPath(expression, args = *arrayOf(args), xpathInit = xpathInit) }
         return this
     }
 

--- a/src/test/kotlin/cz/petrbalat/spring/mvc/test/dsl/controller/DslControllerTest.kt
+++ b/src/test/kotlin/cz/petrbalat/spring/mvc/test/dsl/controller/DslControllerTest.kt
@@ -151,11 +151,12 @@ class DslControllerTest  {
 }
 
 /** Silly example matcher to demonstrate how to add custom matchers that aren't in the DSL using unary operator */
-class HandlerMethod(val name: String): ResultMatcher {
+class HandlerMethod(private val name: String): ResultMatcher {
+
     override fun match(result: MvcResult) {
-        if(result.handler is org.springframework.web.method.HandlerMethod) {
-            val handlerMethod = result.handler as org.springframework.web.method.HandlerMethod
-            AssertionErrors.assertEquals("Handler name", name, handlerMethod.method.name)
+        val handler = result.handler
+        if(handler is org.springframework.web.method.HandlerMethod) {
+            AssertionErrors.assertEquals("Handler name", name, handler.method.name)
         }
     }
 }


### PR DESCRIPTION
I've been playing with the DSL against a complex MockMvc usage (see https://github.com/spring-projects/spring-restdocs/blob/master/samples/rest-notes-slate/src/test/java/com/example/notes/ApiDocumentation.java) as well as verifying it is extensible. I uncovered a few shortcoming with the DSL.

This PR solves:
* Ability to run actions after expectations (ie `document()` call)
* Allow users to add their own custom matchers that aren't baked into the DSL (via unary operator)

I'll also be following up with a PR with a number of negative tests (that would have helped me catch many of these).
Without the unary it appears like you are adding a matcher to the expects, but it is silently ignored.


@petrbalat Thanks for accepting these contributions. I apologize for the churn/noise.
