### PR TITLE
Add finding based on negative tests and restdocs usage

### DIFF
--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslExpectationBuilder.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslExpectationBuilder.kt
@@ -33,7 +33,7 @@ class DslExpectationBuilder(private val actions: ResultActions) {
     fun <T> model(name: String, modelInit: T.() -> Unit) {
         actions.andExpect { mvcResult ->
             val model = mvcResult.modelAndView?.model?.get(name) as T?
-            model?.modelInit()
+            model?.modelInit() ?: throw AssertionError("Model attribute $name was not found")
         }
     }
 
@@ -67,7 +67,7 @@ class DslExpectationBuilder(private val actions: ResultActions) {
         actions.andExpect(xpath)
     }
 
-    fun xPath(expression:String, vararg args:Any, xpathInit: XpathResultMatchers.() -> ResultMatcher) {
+    fun xpath(expression:String, vararg args:Any, xpathInit: XpathResultMatchers.() -> ResultMatcher) {
         val xpath = MockMvcResultMatchers.xpath(expression, args).xpathInit()
         actions.andExpect(xpath)
     }
@@ -89,7 +89,7 @@ class DslExpectationBuilder(private val actions: ResultActions) {
         actions.andExpect(MockMvcResultMatchers.jsonPath(this).block())
     }
 
-    infix fun String.jsonPathIs(value: Any) {
+    infix fun String.jsonPathIs(value: Any?) {
         actions.andExpect(MockMvcResultMatchers.jsonPath(this, CoreMatchers.`is`(value)))
     }
 

--- a/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
+++ b/src/main/kotlin/cz/petrbalat/spring/mvc/test/dsl/DslRequestBuilder.kt
@@ -94,7 +94,7 @@ class DslRequestBuilder(private val requestBuilder: MockHttpServletRequestBuilde
     }
 
     fun expectXPath(expression:String, vararg args:Any, xpathInit: XpathResultMatchers.() -> ResultMatcher): DslRequestBuilder {
-        expect { xPath(expression, args = *arrayOf(args), xpathInit = xpathInit) }
+        expect { xpath(expression, args = *arrayOf(args), xpathInit = xpathInit) }
         return this
     }
 

--- a/src/test/kotlin/cz/petrbalat/spring/mvc/test/dsl/controller/NegativeDslTest.kt
+++ b/src/test/kotlin/cz/petrbalat/spring/mvc/test/dsl/controller/NegativeDslTest.kt
@@ -1,0 +1,84 @@
+package cz.petrbalat.spring.mvc.test.dsl.controller
+
+import cz.petrbalat.spring.mvc.test.dsl.*
+import junit.framework.TestCase.assertTrue
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.*
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.util.AssertionErrors
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.ResultMatcher
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import javax.servlet.http.Cookie
+
+@ExtendWith(SpringExtension::class)
+@ActiveProfiles("test")
+@SpringBootTest(classes = [KD4SMTApplication::class])
+class NegativeDslTest {
+
+    @Autowired
+    lateinit var context: WebApplicationContext
+
+    val mockMvc: MockMvc by lazy {
+        MockMvcBuilders.webAppContextSetup(context).build()
+    }
+
+    @Test
+    fun `hello json`() {
+        val name = "Petr"
+        mockMvc.performGet("/hello/$name") {
+            expect {
+                assertThrows<AssertionError> { content { contentType(MediaType.APPLICATION_ATOM_XML) } }
+                assertThrows<AssertionError> { contentString("Wrong") }
+                assertThrows<AssertionError> { jsonPath("surname", `is`("Wrong")) }
+                assertThrows<AssertionError> { json("""{"name":"wrong"}""") }
+                assertThrows<AssertionError> { jsonPath("surname") { value("wrong") } }
+                assertThrows<AssertionError> { cookie { value("name", "wrong") } }
+                assertThrows<AssertionError> { flash { attribute<String>("name", "wrong") } }
+                assertThrows<AssertionError> { header { stringValues("name", "wrong") } }
+                assertThrows<AssertionError> { model { attributeExists("name", "wrong") } }
+                assertThrows<AssertionError> { model<String>("name") { assertThat(this, `is`("wrong")) } }
+                assertThrows<AssertionError> { redirectedUrl("wrong/Url") }
+                assertThrows<AssertionError> { redirectedUrlPattern("wrong/Url") }
+                assertThrows<AssertionError> { redirectedUrlPattern("wrong/Url") }
+                assertThrows<AssertionError> { status { isAccepted } }
+                assertThrows<AssertionError> { viewName("wrongName") }
+                assertThrows<AssertionError> { ACCEPTED.isStatus() }
+                assertThrows<AssertionError> { "$.surname" jsonPathIs "wrong" }
+                assertThrows<AssertionError> { "$.surname" jsonPathMatcher `is`("wrong") }
+                assertThrows<AssertionError> { "surname" jsonPath { value("wrong") } }
+                assertThrows<AssertionError> { jsonPath("surname") { value("wrong") } }
+                assertThrows<AssertionError> { +HandlerMethod("helloJsonWrong") }
+                assertThrows<AssertionError> { xpath("//h1") { nodeCount(1) } }
+            }
+        }
+    }
+
+    @Test
+    fun `hello html`() {
+        mockMvc.performGet("/hello") {
+            builder {
+                param("name", "Petr")
+            }
+            expect {
+                assertThrows<AssertionError> { xpath("//wrong") { nodeCount(1) } }
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
After [converting several of the restdocs](https://github.com/checketts/spring-restdocs/blob/fd27a676c7dc489c8087c765b36660593c52d028/samples/rest-notes-spring-hateoas/src/test/java/com/example/notes/ApiDocumentation.kt#L199) samples to test out the DSL (and verifying it can be extended)

Here are a few tweaks that I found were needed